### PR TITLE
Do not declare bin stubs as executables

### DIFF
--- a/pageflow-panorama.gemspec
+++ b/pageflow-panorama.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This leads to bundler warnings since executables from different gems
are used.