### PR TITLE
Assign content types when unpacking to S3

### DIFF
--- a/app/models/pageflow/panorama/package.rb
+++ b/app/models/pageflow/panorama/package.rb
@@ -56,7 +56,8 @@ module Pageflow
       def unpacker
         UnpackToS3.new(archive: archive,
                        destination_bucket: attachment_on_s3.s3_bucket,
-                       destination_base_path: unpack_base_path)
+                       destination_base_path: unpack_base_path,
+                       content_type_mapping: Panorama.config.content_type_mapping)
       end
     end
   end

--- a/lib/pageflow/panorama/configuration.rb
+++ b/lib/pageflow/panorama/configuration.rb
@@ -1,11 +1,21 @@
 module Pageflow
   module Panorama
     class Configuration
+      DEFAULT_CONTENT_TYPE_MAPPING = {
+        'css' => 'text/css',
+        'js' => 'application/javascript',
+        'html' => 'text/html',
+        'csv' => 'text/plain'
+      }
+
       attr_accessor :providers, :packages_base_path
+
+      attr_reader :content_type_mapping
 
       def initialize
         @providers = []
         @packages_base_path = ''
+        @content_type_mapping = DEFAULT_CONTENT_TYPE_MAPPING
       end
     end
   end


### PR DESCRIPTION
Some browsers interpret KRPano HTML files as `text/plain` if no content type is provided. S3 only sets content type headers, if content types are supplied as meta data per entry.