### PR TITLE
Add css class to background for slim controls shadow

### DIFF
--- a/app/views/pageflow/panorama/page.html.erb
+++ b/app/views/pageflow/panorama/page.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="backgroundArea">
+  <div class="backgroundArea page_background page_background-for_page_with_player_controls">
     <%= background_image_div(configuration, 'fallback_image') %>
     <%= content_tag(:div, class: 'videoWrapper iframeWrapper', data: {panorama_url: panorama_url(configuration) }) do %>
     <% end %>


### PR DESCRIPTION
The page background of pages with player controls now requires a
special css class.