### PR TITLE
Allow different thumbnail names

### DIFF
--- a/lib/pageflow/panorama/validation/kr_pano.rb
+++ b/lib/pageflow/panorama/validation/kr_pano.rb
@@ -20,7 +20,7 @@ module Pageflow
         end
 
         def find_thumbnail!
-          find_file!('**/mobile_f.jpg', :missing_preview)
+          find_file!('**/*_f.jpg', :missing_preview)
         end
 
         def find_file!(glob, message_i18n_key)


### PR DESCRIPTION
Many KRPano packages no longer include a `mobile_f.jpg` file, which is
used to generate a thumbnail. They do have `pano_f.jpg` files. Work
with any file called `*_f.jpg`.