### PR TITLE
Prevent leaving invalid packages on the file system

### DIFF
--- a/app/models/pageflow/panorama/package.rb
+++ b/app/models/pageflow/panorama/package.rb
@@ -30,11 +30,6 @@ module Pageflow
                                  default_style: :thumbnail,
                                  styles: Pageflow.config.thumbnail_styles))
 
-      # @override
-      def keep_on_filesystem_after_upload_to_s3?
-        true
-      end
-
       def thumbnail_url(*args)
         thumbnail.url(*args)
       end
@@ -47,10 +42,6 @@ module Pageflow
 
       def unpack_base_path
         attachment_on_s3.present? ? File.dirname(attachment_on_s3.path(:unpacked)) : nil
-      end
-
-      def archive
-        @archive ||= Zip::File.open(attachment_on_filesystem.path)
       end
     end
   end

--- a/lib/pageflow/panorama/archive.rb
+++ b/lib/pageflow/panorama/archive.rb
@@ -1,0 +1,16 @@
+module Pageflow
+  module Panorama
+    module Archive
+      def self.for(package)
+        tempfile = Paperclip.io_adapters.for(package.attachment)
+
+        begin
+          yield(Zip::File.open(tempfile.path))
+        ensure
+          tempfile.close
+          tempfile.unlink
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
No longer depend on the package being left on the file system after
upload to S3. Instead re-download from S3 to unpack and always remove.