### PR TITLE
Load subdirectories of `config/locales`.

### DIFF
--- a/lib/pageflow/panorama/engine.rb
+++ b/lib/pageflow/panorama/engine.rb
@@ -7,6 +7,7 @@ module Pageflow
       isolate_namespace Pageflow::Panorama
 
       config.autoload_paths << File.join(config.root, 'lib')
+      config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
     end
   end
 end


### PR DESCRIPTION
Require for translations from `locales/new`.