### PR TITLE
Allow Bundler 2 in development dependencies

### DIFF
--- a/pageflow-panorama.gemspec
+++ b/pageflow-panorama.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'pageflow-support', '~> 13.x'
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'bundler', ['>= 1.0', '< 3']
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.7'
   spec.add_development_dependency 'factory_bot_rails', '~> 4.8'


### PR DESCRIPTION
Required to fix Travis build.