### PR TITLE
Always lookup files by revisions usage scope

### DIFF
--- a/app/assets/javascripts/pageflow/panorama/editor/models/package.js
+++ b/app/assets/javascripts/pageflow/panorama/editor/models/package.js
@@ -1,4 +1,4 @@
-pageflow.panorama.Package = pageflow.HostedFile.extend({
+pageflow.panorama.Package = pageflow.UploadableFile.extend({
   processingStages: [
     {
       name: 'unpacking',

--- a/app/assets/stylesheets/pageflow/panorama/editor.scss
+++ b/app/assets/stylesheets/pageflow/panorama/editor.scss
@@ -1,3 +1,3 @@
-@include pageflow-hosted-file-stage('unpacking') {
+@include pageflow-uploadable-file-stage('unpacking') {
   @include archive-icon;
 }

--- a/app/helpers/pageflow/panorama/packages_helper.rb
+++ b/app/helpers/pageflow/panorama/packages_helper.rb
@@ -1,11 +1,13 @@
 module Pageflow
   module Panorama
     module PackagesHelper
+      include RevisionFileHelper
+
       def panorama_url(configuration)
         if configuration['panorama_source'] == 'url'
           configuration['panorama_url']
         else
-          package = Package.find_by_id(configuration['panorama_package_id'])
+          package = find_file_in_entry(Package, configuration['panorama_package_id'])
           package ? package.index_document_path : nil
         end
       end

--- a/app/models/pageflow/panorama/package.rb
+++ b/app/models/pageflow/panorama/package.rb
@@ -3,7 +3,7 @@ require 'zip'
 module Pageflow
   module Panorama
     class Package < ActiveRecord::Base
-      include HostedFile
+      include UploadableFile
 
       processing_state_machine do
         state 'unpacking'

--- a/app/models/pageflow/panorama/package.rb
+++ b/app/models/pageflow/panorama/package.rb
@@ -14,11 +14,11 @@ module Pageflow
           transition any => 'unpacking'
         end
 
-        event :retry do
+        event :retry_unpacking do
           transition 'unpacking_failed' => 'unpacking'
         end
 
-        before_transition on: :retry do |package|
+        before_transition on: :retry_unpacking do |package|
           JobStatusAttributes.reset(package, stage: :unpacking)
         end
 
@@ -46,6 +46,10 @@ module Pageflow
 
       def unpack_base_path
         attachment_on_s3.present? ? File.dirname(attachment_on_s3.path(:unpacked)) : nil
+      end
+
+      def retry!
+        retry_unpacking!
       end
     end
   end

--- a/pageflow-panorama.gemspec
+++ b/pageflow-panorama.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', '~> 14.x'
+  spec.add_runtime_dependency 'pageflow', '~> 15.x'
   spec.add_runtime_dependency 'rubyzip', '~> 1.1'
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1.17'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
-  spec.add_development_dependency 'pageflow-support', '~> 14.x'
+  spec.add_development_dependency 'pageflow-support', '~> 15.x'
   spec.add_development_dependency 'bundler', ['>= 1.0', '< 3']
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.7'

--- a/spec/factories/panorama_package.rb
+++ b/spec/factories/panorama_package.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module Panorama
+    FactoryBot.define do
+      factory :package, class: Package do
+        attachment { File.open(Engine.root.join('spec', 'fixtures', 'some.txt.zip')) }
+        index_document { true }
+        state { 'unpacked' }
+      end
+    end
+  end
+end

--- a/spec/helpers/pageflow/panorama/packages_helper_spec.rb
+++ b/spec/helpers/pageflow/panorama/packages_helper_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
+require 'pageflow/used_file_test_helper'
 
 module Pageflow
   module Panorama
     describe PackagesHelper do
+      include UsedFileTestHelper
+
       describe '#panorama_url' do
         context 'URL panorama source' do
           it 'should return specified panorama url when panorama source is URL' do
@@ -27,8 +30,7 @@ module Pageflow
         end
 
         it 'should return the packages index document path' do
-          @entry = PublishedEntry.new(create(:entry, :published))
-          panorama_package_file = create(:used_file, model: :package, revision: @entry.revision)
+          panorama_package_file = create_used_file(:package)
           configuration = {
             'panorama_package_id' => panorama_package_file.perma_id
           }

--- a/spec/helpers/pageflow/panorama/packages_helper_spec.rb
+++ b/spec/helpers/pageflow/panorama/packages_helper_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Pageflow
+  module Panorama
+    describe PackagesHelper do
+      describe '#panorama_url' do
+        context 'URL panorama source' do
+          it 'should return specified panorama url when panorama source is URL' do
+            @entry = PublishedEntry.new(create(:entry, :published))
+            configuration = {
+              'panorama_source' => 'url',
+              'panorama_url' => 'S3-url'
+            }
+
+            url = helper.panorama_url(configuration)
+            expect(url).to eq('S3-url')
+          end
+        end
+
+        it 'should return nil if no package can be found' do
+          @entry = PublishedEntry.new(create(:entry, :published))
+          configuration = {
+            'panorama_package_id' => 500
+          }
+
+          expect(helper.panorama_url(configuration)).to be_nil
+        end
+
+        it 'should return the packages index document path' do
+          @entry = PublishedEntry.new(create(:entry, :published))
+          panorama_package_file = create(:used_file, model: :package, revision: @entry.revision)
+          configuration = {
+            'panorama_package_id' => panorama_package_file.perma_id
+          }
+
+          url = helper.panorama_url(configuration)
+          expect(url).to match(/#{panorama_package_file.id}\/unpacked\/#{panorama_package_file.perma_id}/)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/config/factory_bot.rb
+++ b/spec/support/config/factory_bot.rb
@@ -1,0 +1,14 @@
+require 'factory_bot_rails'
+
+RSpec.configure do |config|
+  # Allow to use build and create methods without FactoryBot prefix.
+  config.include FactoryBot::Syntax::Methods
+
+  # Make sure factories are up to date when using spring. Skip in CI
+  # since reloading causes factories to be excluded in test coverage.
+  unless ENV['CI']
+    config.before(:all) do
+      FactoryBot.reload
+    end
+  end
+end


### PR DESCRIPTION
Migrate all existing find_by_id calls to find_file_in_entry(file_type, file_id) calls.
Use UsedFile-factory in specs to set up file usages.

REDMINE-16809